### PR TITLE
feat: Add option to configure animation duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,13 @@ By default, Text2Motion apply root motion to the generated animation. This means
 ![Apply Root Motion](images/Features_apply-root-motion.gif)
 
 Note that with **Apply Root Motion** unchecked, there will be no keyframe for the root bone. If the initial position of the model is away from the origin when the animation is generated, it will render from where the last position was instead of from the origin. You can t-pose the model to move it back to the origin by pressing `A`, `alt+G`, `alt+R`, `alt+S`.
+
+### Configure Animation Duration
+
+By default, Text2Motion will generate animation with estimated duration decided by the model. This means the animation duration could varies from request to request. If you want to control the duration of the animation, you can uncheck **Auto** and enter the durations you want for the generated animation.  
+![Auto Duration](images/Feature_Auto-Duration.png)  
+![Auto Duration](images/Feature_Manual-Duration.png)
+
+Note that since the server only accept duration in seconds, the frames option is rounded to the nearest seconds based on the frame-per-second configuration. By default it is `24`, frames can only be incremented by multiple of `24`.
+
+You can also change the Animation timeline's unit from frames to seconds by pressing `Ctrl+T`

--- a/images/Feature_Auto-Duration.png
+++ b/images/Feature_Auto-Duration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cccdb9e65f5b7e684d3d2b6936a31c43725a2edc2edfceee23431dce453ec8c7
+size 258726

--- a/images/Feature_Manual-Duration.png
+++ b/images/Feature_Manual-Duration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:044a0b3c896c913e5b73e37dd8bc23063c7962b69d92ae862e473154b810598f
+size 307292

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-# Requirements needed both inside of Blender add-on and the development enviornment
+# Requirements needed both inside of Blender add-on and the development environment
 -r requirements.txt
 
-# Requirements needed only in the development enviornment
+# Requirements needed only in the development environment
 fake-bpy-module

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pydantic >= 2
 typing-extensions >= 4.7.1
-text2motion_client_api @ https://github.com/text2motion/python-client/releases/download/releases%2F0.1.0/text2motion_client_api-0.1.0-py3-none-any.whl
+text2motion_client_api @ https://github.com/text2motion/python-client/releases/download/releases%2F0.1.1/text2motion_client_api-0.1.1-py3-none-any.whl

--- a/src/text2motion/t2m_server_request_wrapper.py
+++ b/src/text2motion/t2m_server_request_wrapper.py
@@ -173,7 +173,12 @@ def load_frames(
                 data_path='location', frame=frame)
 
 
-def make_server_request(prompt, target_skeleton, api_key):
+def make_server_request(
+        prompt, 
+        target_skeleton, 
+        seconds,
+        api_key,
+        ):
     logger.info(f"Requesting Text2Motion Server with prompt: {prompt}")
     configuration = text2motion_client_api.Configuration(
         host="https://api.text2motion.ai"
@@ -185,6 +190,7 @@ def make_server_request(prompt, target_skeleton, api_key):
         generate_request_body = text2motion_client_api.GenerateRequestBody(
             prompt=prompt,
             target_skeleton=target_skeleton,
+            seconds=seconds,
         )
 
         # Generate


### PR DESCRIPTION
Problem:
Text2Motion API now supports passing a seconds parameter to configure the duration of the generated animation. We want to port this feature to the blender integration.

Solution:
Added new option panel for passing in the seconds parameter.

Risk:
Any bugs in the extension code could cause the extension to stop working. We will mitigate this risk by testing before releasing.

Testing Done:
Ran the extension locally from devcontainer build and verified the following:
1. Can still set API key
2. License info is still displaying
3. Prompt still works
4. Can change name of action
5. can toggle root motion
6. Auto duration works
7. Seconds and Frames can both be set and generate expected length
8. Verified the parameter are properly bounded

Made a windows and linux build and repeated the above steps on a local blender installation.