### PR TITLE
feat: Add multi-model support

### DIFF
--- a/src/text2motion/t2m_server_request_wrapper.py
+++ b/src/text2motion/t2m_server_request_wrapper.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import math
 from .t2m_animation import T2MFrames
 import logging
@@ -35,6 +36,10 @@ t2m_to_blender_matrix = bpy_extras.io_utils.axis_conversion(from_forward=T2M_FOR
 
 cached_target_skeleton = None
 cached_active_object = None
+
+class ModelVersion(str, Enum):
+    STABLE = 'stable'
+    LAB_V_0_1_0 = 'labs (0.1.0)'
 
 
 def get_target_skeleton(active_object):
@@ -174,10 +179,11 @@ def load_frames(
 
 
 def make_server_request(
-        prompt, 
-        target_skeleton, 
-        seconds,
-        api_key,
+        prompt: str, 
+        target_skeleton: Skeleton, 
+        seconds: int,
+        api_key: str,
+        model_version: ModelVersion = ModelVersion.STABLE
         ):
     logger.info(f"Requesting Text2Motion Server with prompt: {prompt}")
     configuration = text2motion_client_api.Configuration(
@@ -193,7 +199,11 @@ def make_server_request(
             seconds=seconds,
         )
 
-        # Generate
-        api_response = api_instance.generate_api_generate_post(
-            generate_request_body)
+        match model_version:
+            case ModelVersion.LAB_V_0_1_0:
+                api_response = api_instance.generate_api_labs010_generate_post(
+                    generate_request_body)
+            case _:
+                api_response = api_instance.generate_api_generate_post(
+                    generate_request_body)
         return api_response.result


### PR DESCRIPTION
Problem:
Latest Text2motion API now supports multiple model versions.

Solution:
Added a drop down under Advanced Options Panel to allow selecting model version for the request.

Risk:
This modified the request path to the server using the new API. Any error in the code can cause server request to fail. Mitigated by testing all model version to make sure they still works.

Testing Done:
1. Tested devcontainer build and successfully made generate request for both stable and labs 0.1.0.
2. Tested installing local build and verify both model versions.